### PR TITLE
Update `useProducts` hook in `HomePage` to include default limit parameter

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import {Header} from "@/components/header"
 import {useProducts} from "@/src/actions/GetProductsAction";
 
 export default function HomePage() {
-    const {products, isLoading, error} = useProducts();
+    const {products, isLoading, error} = useProducts(4);
     return (
         <div className="min-h-screen bg-background">
             <Header/>


### PR DESCRIPTION
- Modified `useProducts` invocation in `app/page.tsx` to pass a default limit of `4` for fetching products.
- Enhanced consistency in fetching logic by explicitly setting the number of products to load on the HomePage.

This commit optimizes product fetching behavior for the homepage, ensuring a defined default limit and improving clarity in data handling.